### PR TITLE
Fix missing types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,0 @@
-dist/
-node_modules/
-types/


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The .gitignore is used as a fallback whne publishing to exclude files to NPM[^1]. As such, the types were not included in the release. 

Compare the code on NPM between react-native-appwrite and appwrite:
1. [react-native-appwrite](https://www.npmjs.com/package/react-native-appwrite?activeTab=code)
2. [appwrite](https://www.npmjs.com/package/appwrite?activeTab=code)

This PR removes the .gitignore to match the web SDK repo and allow the types to be published to NPM.

[^1]: https://docs.npmjs.com/cli/v9/configuring-npm/package-json#files

Fixes https://github.com/appwrite/sdk-for-react-native/issues/16

## Test Plan

Manual

## Related PRs and Issues

* https://github.com/appwrite/sdk-for-react-native/issues/16

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes