### PR TITLE
fix(realtime): prevent INVALID_STATE_ERROR crash in heartbeat

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -420,14 +420,17 @@ class Client {
             }
         },
         createHeartbeat: () => {
-            if (this.realtime.heartbeat) {
-                clearTimeout(this.realtime.heartbeat);
+            if (this.realtime.heartbeat !== undefined) {
+                clearInterval(this.realtime.heartbeat);
+                this.realtime.heartbeat = undefined;
             }
 
             this.realtime.heartbeat = window?.setInterval(() => {
-                this.realtime.socket?.send(JSONbig.stringify({
-                    type: 'ping'
-                }));
+                if (this.realtime.socket?.readyState === WebSocket.OPEN) {
+                    this.realtime.socket.send(JSONbig.stringify({
+                        type: 'ping'
+                    }));
+                }
             }, 20_000);
         },
         createSocket: () => {


### PR DESCRIPTION
## Summary

Fixes #101

- Replace `clearTimeout` with `clearInterval` when resetting the Realtime heartbeat timer (it was created with `setInterval`, so previous intervals were never cleared and stacked on every reconnect)
- Guard `socket.send()` with a `readyState === WebSocket.OPEN` check so heartbeat pings are not sent on closing/closed sockets during reconnect

This aligns `createHeartbeat()` in `src/client.ts` with the existing pattern in `src/services/realtime.ts`.

## Test plan

- [ ] Open app with an active Realtime subscription
- [ ] Disconnect network, send app to background
- [ ] Reconnect network and wait for connection to re-establish
- [ ] Bring app back to foreground
- [ ] Confirm no `INVALID_STATE_ERROR` crash and Realtime resumes normally